### PR TITLE
Nomo tautomer

### DIFF
--- a/magi_job/mirror_process_submit.py
+++ b/magi_job/mirror_process_submit.py
@@ -97,16 +97,12 @@ for job_data in unrun_jobs:
         job_script = job_script[0]
     script_path = os.path.join(script_dir, job_script)
     submit_protocol = job_script.split('.')[1]
-    if submit_protocol not in ['sbatch', 'qsub']:
+    if submit_protocol not in ['sbatch']:
         print 'Could not determine which machine to submit the following script to: %s' % (script_path)
         continue
 
     if job_script.split('.')[1] == 'sbatch' and 'cori' in host:
         cmd = ['sbatch']
-        cmd.append(script_path)
-        submit = True
-    elif job_script.split('.')[1] == 'qsub' and 'genepool' in host:
-        cmd = ['qsub']
         cmd.append(script_path)
         submit = True
 

--- a/magi_job/utils.py
+++ b/magi_job/utils.py
@@ -467,12 +467,6 @@ def job_script(job_data, n_cpd=None):
     ]
     # need to convert this into string so we can join it later
     score_weights = [str(i) for i in score_weights]
-    
-    # need to interpret tautomer flag
-    if  job_data['fields']['is_tautomers']:
-        tautomer = '--tautomer'
-    else:
-        tautomer = '--no-tautomer'
 
     # estimate timing:
     if n_cpd <= 100:
@@ -536,9 +530,6 @@ def job_script(job_data, n_cpd=None):
         '%s' % (fasta_file_line),
         '%s' % (met_file_line),
         '--level %s \\' % (job_data['fields']['network_level']),
-        # not sure if this line will break anything at nersc
-        # if it does, put it at the end of the previous line
-        '%s \\' % (tautomer),
         '--final_weights %s \\' % (' '.join(score_weights)),
         '--blast_filter %s \\' % (job_data['fields']['blast_cutoff']),
         '--reciprocal_closeness %s \\' % (job_data['fields']['reciprocal_cutoff']),


### PR DESCRIPTION
adjusted the magiweb-facing scripts to deal with the new precomputed workflow.

Initially removed the genepool script writer, but then realized there were some issues submitting jobs to cori and edison realtime queue, so put genepool scripts back in. jobs > 100 compounds now have a walltime of 2 hours, which should be totally okay. 

The realtime scripts are still there, just need to swap some things when the realtime queue things get settled