### PR TITLE
Blast fasta database now stored locally instead of magi/outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ tests/full_workflow_test/test_output_files/
 *nohup*
 *testlog*
 workflow/database/
-workflow/blastbin/blastp
-workflow/blastbin/makeblastdb
+workflow/blastbin/blastp*
+workflow/blastbin/makeblastdb*
 outputs/
 

--- a/README.md
+++ b/README.md
@@ -137,8 +137,6 @@ compounds_df =  ''        # path to compounds database
 mst_path =  ''            # path to chemical similarity network graph
 chemnet_pickle = ''       # path to chemical similarity network descriptions
 
-magi_results_storage = '' # path to where to store magi outputs and blast databases
-
 # The next 2 lines are only required if you are interfacing with magi_web
 magiwebsuperuser = ''     # admin username for magi_web
 magiwebsuperuserpass = '' # admin password for magi_web

--- a/docker/setup_docker.py
+++ b/docker/setup_docker.py
@@ -40,7 +40,6 @@ def main():
     lines.append("chemnet_pickle =    os.path.join(repo_location, 'workflow/database/compound_groups.pkl')\n")
     lines.append("c2r =               os.path.join(repo_location, 'workflow/database/c2r.pkl')\n")
     lines.append("\n")
-    lines.append("magi_results_storage = os.path.join(repo_location, 'outputs')\n")
 
     with open('magi/local_settings/%s.py' %(fname), 'w') as f:
         for line in lines:

--- a/local_settings/template_settings.py
+++ b/local_settings/template_settings.py
@@ -9,6 +9,3 @@ mrs_reaction_path = os.path.join(repo_location, 'workflow/database/mrs_reaction_
 compounds_df =      os.path.join(repo_location, 'workflow/database/unique_compounds_groups_magi.pkl')
 mst_path =          os.path.join(repo_location, 'workflow/database/graph.pkl')
 chemnet_pickle =    os.path.join(repo_location, 'workflow/database/compound_groups.pkl')
-
-magi_results_storage = os.path.join(repo_location, 'outputs')
-

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ def main():
         lines.append("chemnet_pickle =    os.path.join(repo_location, 'workflow/database/compound_groups.pkl')\n")
         lines.append("c2r =               os.path.join(repo_location, 'workflow/database/c2r.pkl')\n")
         lines.append("\n")
-        lines.append("magi_results_storage = os.path.join(repo_location, 'outputs')\n")
         lines.append("magi_task_path = ''\n")
         lines.append("magiweburl = 'https://magi.nersc.gov'\n")
         lines.append("magiwebsuperuser = ''\n")

--- a/setup_windows.py
+++ b/setup_windows.py
@@ -26,6 +26,9 @@ def main():
     if args.f:
         extract_database = True
         set_paths = True
+    else:
+        extract_database = True
+        set_paths = True
     
     if set_paths:
         fname = raw_input('USER INPUT: Settings Name (leave blank for default): ')
@@ -63,7 +66,6 @@ def main():
         lines.append("chemnet_pickle =    os.path.join(repo_location, 'workflow','database','compound_groups.pkl')\n")
         lines.append("c2r =               os.path.join(repo_location, 'workflow','database','c2r.pkl')\n")
         lines.append("\n")
-        lines.append("magi_results_storage = os.path.join(repo_location, 'outputs')\n")
         lines.append("magi_task_path = ''\n")
         lines.append("magiweburl = 'https://magi.nersc.gov'\n")
         lines.append("magiwebsuperuser = ''\n")

--- a/workflow/magi_workflow.py
+++ b/workflow/magi_workflow.py
@@ -242,20 +242,19 @@ if args.mute:
 # import workflow helpers after all the argument checking
 import workflow_helpers as mg
 
-# path to MAGI data storage
-MAGI_PATH = my_settings.magi_results_storage
-
 # set up where the results will be stored
 if args.output is None:
 	# autoname the directory based on fasta, or compound file
 	# this will change eventually
 	if args.fasta is not None:
-		experiment_name = os.path.splitext(os.path.basename(args.fasta.split))[0]
+		experiment_name = os.path.splitext(os.path.basename(args.fasta))[0]
+		experiment_dir = os.path.abspath(os.path.dirname(args.fasta))
 	else:
 		experiment_name = os.path.splitext(os.path.basename(args.compounds))[0]
+		experiment_dir = os.path.abspath(os.path.dirname(args.compounds))
 	today = datetime.datetime.now()
 	experiment_name += today.strftime('_%Y%m%d')
-	experiment_path = os.path.join(MAGI_PATH, experiment_name)
+	experiment_path = os.path.join(experiment_dir, experiment_name)
 else:
 	experiment_path = args.output
 
@@ -271,7 +270,7 @@ main_start = time.time() # overall program timer
 if args.fasta is not None:
 	# load genome
 	print '\n!!! LOADING GENOME'
-	genome, genome_db_path = mg.load_genome(args.fasta, MAGI_PATH, 
+	genome, genome_db_path = mg.load_genome(args.fasta, intfile_path, 
 										annotation_file=args.annotations)
 
 if args.accurate_mass_search is not None:

--- a/workflow/workflow_helpers.py
+++ b/workflow/workflow_helpers.py
@@ -265,7 +265,7 @@ def ec_parse(x):
     else:
         return out
 
-def load_genome(fasta, MAGI_PATH, annotation_file=None):
+def load_genome(fasta, intfile_path, annotation_file=None):
     """
     This function will take some standard fasta a input and convert it
     to an appropriate genome dataframe.
@@ -278,7 +278,7 @@ def load_genome(fasta, MAGI_PATH, annotation_file=None):
            >UNIQUE_GENE_IDENTIFIER OTHER_INFORMATION
            Note the space between the unique identifier and other info
 
-    MAGI_PATH: path to the root directory of MAGI Data. If None, the
+    intfile_path: path to the temporary storage place of the database. If None, the
                BLAST database is not made, and the gene table is not
                stored.
 
@@ -291,7 +291,7 @@ def load_genome(fasta, MAGI_PATH, annotation_file=None):
     -------
     genome: gene sequence table that is merged with the annotation table
             if one is provided. This table is saved as a pickle file to
-            MAGI_PATH/gene_fastas/filename.pkl
+            intfile_path/gene_fastas/filename.pkl
     db_path: path to the genome's BLAST database
     """
     # TODO: find a way to handle windows text files (\n\r for new lines)
@@ -305,10 +305,10 @@ def load_genome(fasta, MAGI_PATH, annotation_file=None):
 
     data = []
     for entry in genes.split('>')[1:]:
-        h = '>' + entry.split('\n')[0]
-        img = h.split(' ')[0][1:]
-        s = ''.join(entry.split('\n')[1:])
-        data.append([img, h, s])
+        header = '>' + entry.splitlines()[0]
+        gene_id = header.split(' ')[0][1:]
+        sequence = ''.join(entry.splitlines()[1:])
+        data.append([gene_id, header, sequence])
     genome = pd.DataFrame(data, columns=['Gene_ID', 'header', 'sequence'])
     if genome['Gene_ID'].duplicated().any():
         first_dup = genome[genome['Gene_ID'].duplicated()].head(1)
@@ -346,34 +346,33 @@ def load_genome(fasta, MAGI_PATH, annotation_file=None):
 
     genome.set_index('Gene_ID', inplace=True, drop=True)
     genome_name = os.path.splitext(os.path.basename(fasta))[0]
-    if MAGI_PATH is not None:
-        gene_fasta_path = os.path.join(MAGI_PATH, 'gene_fastas')
+    if intfile_path is not None:
+        gene_fasta_path = os.path.join(intfile_path, 'gene_fastas')
         if not os.path.isdir(gene_fasta_path):
             os.makedirs(gene_fasta_path)
         gene_seq_path = os.path.join(gene_fasta_path,
             '%s_sequences.pkl' % (genome_name))
         # gene_seq_path = '%s/gene_fastas/%s_sequences.pkl' \
-        #                 % (MAGI_PATH, genome_name)
+        #                 % (intfile_path, genome_name)
         genome.to_pickle(gene_seq_path)
         print '!!! saved gene_sequence table here:', gene_seq_path
 
-        # Make the blast database of the fasta if it doesn't already exist
+        # Make the blast database of the fasta
         # this command makes the blast database for a given fasta file.
-        makeblastdb_path = '%s/makeblastdb' % (blastbin)
+        makeblastdb_path = os.path.join(blastbin, 'makeblastdb')
         fasta_path = fasta
-        db_path = os.path.join(MAGI_PATH, 'BLAST_dbs',(os.path.splitext(os.path.basename(fasta_path))[0]+'.db'))
+        db_path = os.path.join(intfile_path, 'BLAST_dbs',(os.path.splitext(os.path.basename(fasta_path))[0]+'.db'))
         print '!!! blast database stored here:', db_path
         make_db_command = '%s -in %s -out %s -dbtype prot' \
             % (makeblastdb_path, fasta_path, db_path)
-        if not os.path.isfile(db_path + '.pin'):
-            blastp = subprocess.Popen(
-                make_db_command,
-                shell=True, stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-            if blastp.stdout is not None:
-                print blastp.stdout.read()
-            if blastp.stderr is not None:
-                print blastp.stderr.read()
+        blastp = subprocess.Popen(
+            make_db_command,
+            shell=True, stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        if blastp.stdout is not None:
+            print blastp.stdout.read()
+        if blastp.stderr is not None:
+            print blastp.stderr.read()
     else:
         db_path = None
     return genome, db_path
@@ -494,7 +493,7 @@ def multi_blast(query_list, query_full_table, database_path, result_path,
     # call a shell script that opens n blasts,
     # instead of opening pool of workers
     # first need to save the input seq as a temporary file
-    cwd = result_path + '/' + 'multi_blast_files'
+    cwd = os.path.join(result_path, 'multi_blast_files')
     if not os.path.isdir(cwd):
         os.makedirs(cwd)
     for i, seq in enumerate(mplist):
@@ -502,18 +501,18 @@ def multi_blast(query_list, query_full_table, database_path, result_path,
             f.write(seq)
 
     # then call the job
-    scriptpath = '%s/recip_blaster.sh' % (blastbin)
+    scriptpath = os.path.join(blastbin, 'recip_blaster.sh')
     print '!!! blast script:', scriptpath
     print '!!! # processes to open:', cpu
     print '!!! database path:', database_path
     print '!!! results stored:', cwd
     sys.stdout.flush()
+    blaster_file = "{}__{}.txt".format(os.path.join(result_path, 'blasterr'), db_name)
     subprocess.call(
-        '%s %s %s %s %s 2> %s/blasterr__%s.txt'
-        % (scriptpath, cpu, database_path, cwd, my_settings.repo_location,
-            result_path, db_name),
+        '%s %s %s %s %s 2> %s'
+        % (scriptpath, cpu, database_path, cwd, my_settings.repo_location,blaster_file),
         shell=True)
-    with open('%s/blasterr__%s.txt' % (result_path, db_name), 'r') as f:
+    with open(blaster_file, 'r') as f:
         msg = f.read()
     if msg != '':
         print '!@# WARNING: BLAST script error message:'
@@ -526,7 +525,7 @@ def multi_blast(query_list, query_full_table, database_path, result_path,
     # collect the results
     results = ''
     for i, seq in enumerate(mplist):
-        with open('%s/tmp_out_blasted_%s.txt' % (cwd, i), 'r') as f:
+        with open(os.path.join(cwd, 'tmp_out_blasted_%s.txt' % i), 'r') as f:
             results += f.read()
     results_table = tabulate_blast(results)
 


### PR DESCRIPTION
Now, magi makes a new database from a fasta genome. This fixes the bug where no new database was made when the fasta filename matched a name that was already used before. Also, a not-very-neat-quick fix was added to run the windows versions of BLAST (blastp.exe instead of just blastp)